### PR TITLE
add contributors guide and code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,77 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and it also applies when
+an individual is representing the project or its community in public spaces.
+Examples of representing a project or community include using an official
+project e-mail address, posting via an official social media account, or acting
+as an appointed representative at an online or offline event. Representation of
+a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at chris.armstrong@gorillastack.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contribution Guidelines
+
+## Rationale
+
+JMESPath itself is a group of related projects implementing the same specification
+in different languages.
+
+This is a fork of the original JavaScript implementation (jmespath.js), hosted at
+[Github](https://github.com/jmespath/jmespath.js)). It is maintained by
+[GorillaStack](https://www.gorillastack.com).
+
+From what we can ascertain, the original specification has not been maintained for
+some years and the JavaScript fork has not accepted patches or responded to issues
+for some time (Some of the other language implementations do appear to be maintained).
+We believe this project is still useful, so we are making improvements and
+fixing bugs in this copy of the code.
+
+## Contributing to this project
+
+> Please note that this project is released with a [Contributor Code of Conduct](CODE_OF_CONDUCT.md). By
+> participating in this project you agree to abide by its terms.
+
+### Opening issues
+
+You should include:
+
+- your JavaScript interpreter details i.e. nodejs version or browser version
+- an example JMESPath expression that reproduces your issue
+- an associated JSON example that is used by your expression
+- any other relevant information
+
+**NOTE**: We are only maintaining the JavaScript fork at this time - issues in
+implementations for other languages (C#, Java, Python, etc.) should be directed
+at the relevant repository (see our [documentation site](https://gorillstack-jmespath.netlify.com)
+for a list of links for each language implementation).
+
+### Bug fixes
+
+Please open a pull request with a description of the bug or a link to an issue
+as well as you code. Include updates to the compliance or test suite (where
+appropriate) that demonstrate the fix to your issue.
+
+### New functionality
+
+*NOTE: We are not the original maintainers of the specification, but we are making*
+*adding to it in our fork to support new functionality.*
+
+To make it easier for those who may want to adapt our additions for other
+implementations, we require you to write up a specification, in addition to
+your JavaScript implementation. This process allows other language maintainers
+of jmespath to add your changes to their language.
+
+1. First, start by taking a copy of the GorillaStack [jmespath.site repository](https://github.com/GorillaStack/jmespath.site)
+  and adding a proposal to the `docs/proposals` directory. Follow the format
+  of existing proposals (Title, Abstract, Motivations, Syntax) and link to
+  it in the `docs/proposals.rst` file. Open a PR on the [jmespath.site repository](https://github.com/GorillaStack/jmespath.site)
+2. Open a PR on this repository with a working implementation. You will need
+  to update `/jmespath.js` and add test cases to the `test/compliance` directory
+  that validate your spec additions (these are important for other langugage
+  maintainers that use the same compliance suite).
+3. We may provide feedback or request additional changes to your PRs to accept
+  them.
+4. When they are ready, we'll get you to submit an additional PR to the specification
+  that describes your new additions. They should be correctly flagged as
+  diversions from the original specification unique to the JavaScript
+  implementation.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright 2014 James Saryerwinnie
+Copyright 2019 GorillaStack
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -46,12 +46,20 @@ from a list.  Here are a few more examples:
 The example above only show a small amount of what
 a JMESPath expression can do.  If you want to take a
 tour of the language, the *best* place to go is the
-[JMESPath Tutorial](http://jmespath.org/tutorial.html).
+[JMESPath Tutorial](https://gorillastack-jmespath.netlify.com/tutorial.html).
 
 One of the best things about JMESPath is that it is
 implemented in many different programming languages including
 python, ruby, php, lua, etc.  To see a complete list of libraries,
-check out the [JMESPath libraries page](http://jmespath.org/libraries.html).
+check out the [JMESPath libraries page](https://gorillastack-jmespath.netlify.com/libraries.html).
 
 And finally, the full JMESPath specification can be found
-on the [JMESPath site](http://jmespath.org/specification.html).
+on the [JMESPath site](https://gorillastack-jmespath.netlify.com/specification.html).
+
+## Contributing
+
+Although this is a copy of the original jmespath.js repository, we are
+accepting contributions!
+
+Please see our [Contribution Guidelines](CONTRIBUTING.md) and our
+[Code of Conduct](CODE_OF_CONDUCT.md).


### PR DESCRIPTION
Add contribution guidelines and an associated code of conduct

Redirect links to GorillaStack copy of documentation.